### PR TITLE
Added missing resolveIntersections function

### DIFF
--- a/src/ofxCorkCsg.cpp
+++ b/src/ofxCorkCsg.cpp
@@ -90,6 +90,14 @@ namespace ofxCorkCsg
         freeCorkTriMesh(&corkOutMesh);
     }
     
+    void resolveIntersections(const MeshWrapper& in0, const MeshWrapper& in1, ofMesh& outMesh)
+    {
+        CorkTriMesh corkOutMesh;
+        resolveIntersections(in0.corkTriMesh, in1.corkTriMesh, &corkOutMesh);
+        toOf(corkOutMesh, outMesh);
+        freeCorkTriMesh(&corkOutMesh);
+    }
+
     void toOf(const CorkTriMesh& inMesh, ofMesh& outMesh)
     {
         outMesh.clear();


### PR DESCRIPTION
Hi!

I was just trying to build ofxCorkCsg and was getting a linker error.  It looks like there is a missing wrapper function.  I used computeIntersection as a template to create the missing resolveIntersections.  This compiles now, but I haven't tested this function (not sure how the lib works exactly yet).  So you might want to double check it.

Cheers!
Sam